### PR TITLE
[docs] Fix ending code fence on RSR page

### DIFF
--- a/docs/recipes/scilla-contract/remoteread.md
+++ b/docs/recipes/scilla-contract/remoteread.md
@@ -18,7 +18,7 @@ A remote state read is the mechanism to read another contract state from any ano
 
 ```ByStr20 with contract end```: A ByStr20 which, when interpreted as a network address, refers to the address of a contract.
 
-```ByStr20 with contract field f1``` : t1, field f2 : t2, ... end: A ByStr20 which, when interpreted as a network address, refers to the address of a contract containing the mutable fields f1 of type t1, f2 of type t2, and so on. The contract in question may define more fields than the ones specified in the type, but the fields specified in the type must be defined in the contract.
+```ByStr20 with contract field f1 : t1, field f2 : t2, ... end```: A ByStr20 which, when interpreted as a network address, refers to the address of a contract containing the mutable fields f1 of type t1, f2 of type t2, and so on. The contract in question may define more fields than the ones specified in the type, but the fields specified in the type must be defined in the contract.
 
 ## Inline fetch
 


### PR DESCRIPTION
# Scilla Cookbook Amendments

## Description

The code fence endpoint for a contract with several mutable fields was positioned too early

## Title



## Assets



## Testing

- [x ] My changes add value
- [x] My pull request title is meaningful
- [x] I have compiled the cookbook website locally to test my changes
- [x] My changes do not cause errors in the browser terminal
- [x] I have performed a self-review of my amended files
- [x] My .md changes are well-formatted cause no markdown warnings
