### PR TITLE
Fix semicolons

### DIFF
--- a/docs/recipes/scilla-recipes/messages.md
+++ b/docs/recipes/scilla-recipes/messages.md
@@ -70,13 +70,13 @@ contract Proxy()
 
 transition ProxyPressButton(example_contract_address: ByStr20)
     i_value = Uint256 44;
-    b_value = example_contract_address
+    b_value = example_contract_address;
     example_contract_call = {
         _tag: "ExampleWithParams";
         _recipient: example_contract_address;
         _amount: Uint128 0;
         int_value: i_value;
-        bystr_value: b_value;
+        bystr_value: b_value
     };
     msgs = one_msg example_contract_call;
     send msgs


### PR DESCRIPTION
# Scilla Cookbook Amendments

## Description

Brief fix of semicolon syntax error within the "Messages, callbacks & contract-to-contract interaction" cookbook. 

## Testing

- [x] My changes add value
- [x] My pull request title is meaningful
- [ ] I have compiled the cookbook website locally to test my changes
- [ ] My changes do not cause errors in the browser terminal
- [ ] I have performed a self-review of my amendmened files
- [ ] My .md changes are well formatted cause no markdown warnings
- [ ] I have run /mdspell
